### PR TITLE
Get Valid File Path for Saving PDF to Disk

### DIFF
--- a/Print2PDF/InvoiceComposer.swift
+++ b/Print2PDF/InvoiceComposer.swift
@@ -117,7 +117,7 @@ class InvoiceComposer: NSObject {
         
         let pdfData = drawPDFUsingPrintPageRenderer(printPageRenderer: printPageRenderer)
         
-        pdfFilename = "\(AppDelegate.getAppDelegate().getDocDir())/Invoice\(invoiceNumber).pdf"
+        pdfFilename = "\(AppDelegate.getAppDelegate().getDocDir())/Invoice\(invoiceNumber!).pdf"
         pdfData?.write(toFile: pdfFilename, atomically: true)
         
         print(pdfFilename)


### PR DESCRIPTION
Fix an issue that was preventing the app from obtaining a valid file path for saving the PDF to disk after rendering
