### PR TITLE
Changed insets in CustomPrintPageRenderer.swift

### DIFF
--- a/Print2PDF/CustomPrintPageRenderer.swift
+++ b/Print2PDF/CustomPrintPageRenderer.swift
@@ -26,8 +26,11 @@ class CustomPrintPageRenderer: UIPrintPageRenderer {
         
         // Set the horizontal and vertical insets (that's optional).
         // self.setValue(NSValue(CGRect: pageFrame), forKey: "printableRect")
-        self.setValue(NSValue(cgRect: pageFrame.insetBy(dx: 10.0, dy: 10.0)), forKey: "printableRect")
-        
+        // self.setValue(NSValue(cgRect: pageFrame.insetBy(dx: 10.0, dy: 10.0)), forKey: "printableRect")
+        // UIEdgeInsetsMake(top, left, bottom, right)
+        let insets = UIEdgeInsetsMake(10, 10, 50, 10)
+        let pageFrameWithInsets = UIEdgeInsetsInsetRect(pageFrame, insets)
+        self.setValue(NSValue(cgRect: pageFrameWithInsets), forKey: "printableRect")
         
         self.headerHeight = 50.0
         self.footerHeight = 50.0


### PR DESCRIPTION
Used UIEdgeInsetsMake to differentiate the top and bottom insets because before, there was overlap between the body and footer of the pdf file. Therefore, I made the bottom inset equal to the size of the footer to ensure no overlap. Here's an example of what it looked like before with the overlap,

![simulator screen shot - iphone 7 - 2018-01-11 at 19 42 10](https://user-images.githubusercontent.com/13881485/34854423-9ef0c464-f707-11e7-842f-59d192b1fc78.png)

And here's how it looks after changing the bottom inset to the footer height,

![simulator screen shot - iphone 7 - 2018-01-11 at 19 40 16](https://user-images.githubusercontent.com/13881485/34854426-a396176c-f707-11e7-969d-d38aa19860e3.png)

I'm not quite sure why the overlap does not occur with the header as well as the oddity that the first and only the first page has an extra inset towards the top of the page.